### PR TITLE
Add Hardhat tasks for Factories.

### DIFF
--- a/hardhat/README.md
+++ b/hardhat/README.md
@@ -40,6 +40,8 @@ npx hardhat --network rinkeby add-factory --factory-name AmountPiggyBankFactory 
 
 Verifies and publishes Piggy Bank source code. A new Piggy Bank contract will be deployed in order to link the sources to it.
 
+Please specify etherscan API key in the `etherscan.apiKey.rinkeby` setting in the [hardhat.config.js](./hardhat.config.js) file before running the task. Please follow [official instructions](https://info.etherscan.com/etherscan-developer-api-key/) to get the key.
+
 Example:
 ```sh
 npx hardhat --network rinkeby verify-piggy-bank-at-etherscan --factory-address 0xB5EBdf51651D0d1a5E9b03c703fF1bBB2e3A4189 --factory-name AmountPiggyBankFactory --master-address 0x86b85d9b3e9f3Dc0A7803286ad32A78c43aD3215 --piggy-bank-name AmountPiggyBank --create-method "createAmountPiggyBank(address,string,uint256)" --create-arg-list "0x86b85d9b3e9f3Dc0A7803286ad32A78c43aD3215;Amount Piggy Bank #001;1001"
@@ -48,6 +50,8 @@ npx hardhat --network rinkeby verify-piggy-bank-at-etherscan --factory-address 0
 ### `add-factory-and-verify-piggy-bank-at-etherscan`
 
 Combines [`add-factory`](#add-factory) and [`verify-piggy-bank-at-etherscan`](#verify-piggy-bank-at-etherscan) tasks. It creates a new Factory and registers it in [`Master`](./contracts/PiggyBankMaster.sol), and then verifies and publishes Piggy Bank source code.
+
+Please specify etherscan API key in the `etherscan.apiKey.rinkeby` setting in the [hardhat.config.js](./hardhat.config.js) file before running the task. Please follow [official instructions](https://info.etherscan.com/etherscan-developer-api-key/) to get the key.
 
 Example:
 ```sh

--- a/hardhat/README.md
+++ b/hardhat/README.md
@@ -40,7 +40,7 @@ npx hardhat --network rinkeby add-factory --factory-name AmountPiggyBankFactory 
 
 Verifies and publishes Piggy Bank source code. A new Piggy Bank contract will be deployed in order to link the sources to it.
 
-Please specify etherscan API key in the `etherscan.apiKey.rinkeby` setting in the [hardhat.config.js](./hardhat.config.js) file before running the task. Please follow [official instructions](https://info.etherscan.com/etherscan-developer-api-key/) to get the key.
+Please specify etherscan API key in the `etherscan.apiKey.rinkeby` setting in the [hardhat.config.js](./hardhat.config.js) file before running the task. Please follow [official instructions](https://docs.etherscan.io/getting-started/viewing-api-usage-statistics) to get the key.
 
 Example:
 ```sh
@@ -51,7 +51,7 @@ npx hardhat --network rinkeby verify-piggy-bank-at-etherscan --factory-address 0
 
 Combines [`add-factory`](#add-factory) and [`verify-piggy-bank-at-etherscan`](#verify-piggy-bank-at-etherscan) tasks. It creates a new Factory and registers it in [`Master`](./contracts/PiggyBankMaster.sol), and then verifies and publishes Piggy Bank source code.
 
-Please specify etherscan API key in the `etherscan.apiKey.rinkeby` setting in the [hardhat.config.js](./hardhat.config.js) file before running the task. Please follow [official instructions](https://info.etherscan.com/etherscan-developer-api-key/) to get the key.
+Please specify etherscan API key in the `etherscan.apiKey.rinkeby` setting in the [hardhat.config.js](./hardhat.config.js) file before running the task. Please follow [official instructions](https://docs.etherscan.io/getting-started/viewing-api-usage-statistics) to get the key.
 
 Example:
 ```sh

--- a/hardhat/README.md
+++ b/hardhat/README.md
@@ -1,0 +1,55 @@
+# Piggy Bank (Solidity)
+
+Piggy Bank is a set of the following interacting contracts:
+* [`Master`](./contracts/PiggyBankMaster.sol) contract that is the core of the system
+* Factories that are able to produce Piggy Banks of their specific type and notify Master about each new creation
+* Piggy Banks of various types created by their Factories
+
+The idea is to make it possible to introduce new Piggy Bank types without need to affect source code of contracts that were already deployed. In order to achieve that, it's enough to develop and deploy a new Factory contract that is able to create Piggy Banks of a new type, and register the new Factory in the Master.
+
+## Hardhat deploy
+
+Command that deploys [`Master`](./contracts/PiggyBankMaster.sol) contract to Rinkeby network:
+```sh
+npx hardhat --network rinkeby run scripts/deploy.js
+```
+
+## Hardhat tasks
+
+To get help on a task, run the command in the [`hardhat`](/hardhat/) directory:
+```sh
+cd hardhat
+npx hardhat help {task-name}
+```
+
+For instance, the following command prints help for the [`add-factory`](#add-factory) task:
+```sh
+npx hardhat help add-factory
+```
+
+### `add-factory`
+
+Creates a new Factory and registers it in [`Master`](./contracts/PiggyBankMaster.sol). Returns the address of the Factory created.
+
+Example:
+```sh
+npx hardhat --network rinkeby add-factory --factory-name AmountPiggyBankFactory --master-address 0x86b85d9b3e9f3Dc0A7803286ad32A78c43aD3215 --piggy-bank-type "Amount 001"
+```
+
+### `verify-piggy-bank-at-etherscan`
+
+Verifies and publishes Piggy Bank source code. A new Piggy Bank contract will be deployed in order to link the sources to it.
+
+Example:
+```sh
+npx hardhat --network rinkeby verify-piggy-bank-at-etherscan --factory-address 0xB5EBdf51651D0d1a5E9b03c703fF1bBB2e3A4189 --factory-name AmountPiggyBankFactory --master-address 0x86b85d9b3e9f3Dc0A7803286ad32A78c43aD3215 --piggy-bank-name AmountPiggyBank --create-method "createAmountPiggyBank(address,string,uint256)" --create-arg-list "0x86b85d9b3e9f3Dc0A7803286ad32A78c43aD3215;Amount Piggy Bank #001;1001"
+```
+
+### `add-factory-and-verify-piggy-bank-at-etherscan`
+
+Combines [`add-factory`](#add-factory) and [`verify-piggy-bank-at-etherscan`](#verify-piggy-bank-at-etherscan) tasks. It creates a new Factory and registers it in [`Master`](./contracts/PiggyBankMaster.sol), and then verifies and publishes Piggy Bank source code.
+
+Example:
+```sh
+npx hardhat --network rinkeby add-factory-and-verify-piggy-bank-at-etherscan --piggy-bank-name AmountPiggyBank --factory-name AmountPiggyBankFactory --piggy-bank-type "Amount 002" --master-address 0x86b85d9b3e9f3Dc0A7803286ad32A78c43aD3215 --create-method "createAmountPiggyBank(address,string,uint256)" --create-arg-list "0x86b85d9b3e9f3Dc0A7803286ad32A78c43aD3215;Amount Piggy Bank #001;1001"
+```

--- a/hardhat/hardhat.config.js
+++ b/hardhat/hardhat.config.js
@@ -1,4 +1,6 @@
 require("@nomicfoundation/hardhat-toolbox");
+require("@nomiclabs/hardhat-etherscan");
+require("./tasks/factory_tasks.js");
 
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
@@ -7,6 +9,23 @@ module.exports = {
    rinkeby: {
      url: "https://rinkeby.infura.io/v3/c05bb1b85f24494c9f25b359b17076b2", 
      accounts: ["db0078e71dc0671049d5a7c74e810b6d6be126267afab3a6701efeefbd3e7cff"] 
+    }
+  },
+  etherscan: {
+    // Your API key for Etherscan
+    // Obtain one at https://etherscan.io/
+    apiKey: {
+      rinkeby: "{API_KEY}"
     },
+    customChains: [
+      {
+        network: "rinkeby",
+        chainId: 4,
+        urls: {
+          apiURL: "https://api-rinkeby.etherscan.io/api",
+          browserURL: "https://rinkeby.etherscan.io"
+        }
+      }
+    ]
   }
 };

--- a/hardhat/package-lock.json
+++ b/hardhat/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^1.0.2",
+        "@nomiclabs/hardhat-etherscan": "^3.1.0",
         "hardhat": "^2.11.1"
       }
     },
@@ -1660,7 +1661,6 @@
       "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.1.0.tgz",
       "integrity": "sha512-JroYgfN1AlYFkQTQ3nRwFi4o8NtZF7K/qFR2dxDUgHbCtIagkUseca9L4E/D2ScUm4XT40+8PbCdqZi+XmHyQA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@ethersproject/address": "^5.0.2",
@@ -2575,7 +2575,6 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2737,7 +2736,6 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
       "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -3129,7 +3127,6 @@
       "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
       "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "bignumber.js": "^9.0.1",
         "nofilter": "^1.0.4"
@@ -5321,8 +5318,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -6925,8 +6921,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -7726,7 +7721,6 @@
       "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
       "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8248,7 +8242,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -9122,7 +9115,6 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -9140,7 +9132,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -9156,7 +9147,6 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -9168,8 +9158,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/solc": {
       "version": "0.7.3",
@@ -9800,7 +9789,6 @@
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
       "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -9853,7 +9841,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -9869,8 +9856,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/tar": {
       "version": "4.4.19",
@@ -10406,7 +10392,6 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -13299,7 +13284,6 @@
       "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.1.0.tgz",
       "integrity": "sha512-JroYgfN1AlYFkQTQ3nRwFi4o8NtZF7K/qFR2dxDUgHbCtIagkUseca9L4E/D2ScUm4XT40+8PbCdqZi+XmHyQA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ethersproject/abi": "^5.1.2",
         "@ethersproject/address": "^5.0.2",
@@ -14072,8 +14056,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "async": {
       "version": "2.6.4",
@@ -14201,8 +14184,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
       "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -14531,7 +14513,6 @@
       "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
       "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "bignumber.js": "^9.0.1",
         "nofilter": "^1.0.4"
@@ -16363,8 +16344,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "fast-glob": {
       "version": "3.2.12",
@@ -17587,8 +17567,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "log-symbols": {
       "version": "4.1.0",
@@ -18210,8 +18189,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
       "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "nopt": {
       "version": "3.0.6",
@@ -18621,8 +18599,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "qs": {
       "version": "6.11.0",
@@ -19282,7 +19259,6 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -19294,7 +19270,6 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
-          "peer": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -19304,7 +19279,6 @@
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
-          "peer": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -19313,8 +19287,7 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -19811,7 +19784,6 @@
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
       "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -19825,7 +19797,6 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "dev": true,
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -19837,8 +19808,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -20274,7 +20244,6 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/hardhat/package.json
+++ b/hardhat/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^1.0.2",
+    "@nomiclabs/hardhat-etherscan": "^3.1.0",
     "hardhat": "^2.11.1"
   }
 }

--- a/hardhat/tasks/factory_tasks.js
+++ b/hardhat/tasks/factory_tasks.js
@@ -1,4 +1,4 @@
-const { task, types } = require("hardhat/config");
+const { task } = require("hardhat/config");
 
 const MIN_CONFIRMATIONS_TO_WAIT = 6;
 
@@ -21,7 +21,7 @@ task(
     console.log(`Deploying ${factoryName}...`);
 
     const Factory = await ethers.getContractFactory(factoryName);
-    const factory = await Factory.deploy(ethers.utils.getAddress(masterAddress));
+    const factory = await Factory.deploy(masterAddress);
     await factory.deployed();
 
     console.log(`${factoryName} deployed to ${factory.address}.`);
@@ -102,7 +102,7 @@ task(
     } catch (error) {
       if (error.toString().includes("Reason: Already Verified")) {
         console.log(`${piggyBankName} source code was already verified.`);
-        
+
       } else {
         throw error;
       }

--- a/hardhat/tasks/factory_tasks.js
+++ b/hardhat/tasks/factory_tasks.js
@@ -1,0 +1,149 @@
+const { task, types } = require("hardhat/config");
+
+const MIN_CONFIRMATIONS_TO_WAIT = 6;
+
+task(
+  "add-factory",
+  "Creates a new Factory and registers it in Master.")
+.addParam("factoryName", "The name of the Piggy Bank Factory contract.")
+.addParam("piggyBankType", "The key under which the Factory will be registered in the Master.")
+.addParam("masterAddress", "The address of the Piggy Bank Master contract.")
+.setAction(async ({
+    factoryName,
+    piggyBankType,
+    masterAddress
+  }, {
+    ethers
+  }) => {
+    const Master = await ethers.getContractFactory("PiggyBankMaster");
+    const master = Master.attach(masterAddress);
+
+    console.log(`Deploying ${factoryName}...`);
+
+    const Factory = await ethers.getContractFactory(factoryName);
+    const factory = await Factory.deploy(ethers.utils.getAddress(masterAddress));
+    await factory.deployed();
+
+    console.log(`${factoryName} deployed to ${factory.address}.`);
+
+    console.log(`Registering ${factoryName} in Master...`);
+
+    const registerTx = await master.registerPiggyBankFactory(
+      piggyBankType,
+      factory.address);
+
+    await registerTx.wait();
+
+    console.log(`${factoryName} registered in Master.`);
+
+    return factory.address;
+  }
+);
+
+// TODO:  Iterate through all Factories, parse their ABI,
+//        and create specific verification tasks for each Factory.
+task(
+  "verify-piggy-bank-at-etherscan",
+  "Verifies and publishes Piggy Bank source code. " +
+  "A new Piggy Bank contract will be deployed in order to link the sources to it.")
+.addParam("piggyBankName", "The name of the Piggy Bank contract.")
+.addOptionalParam("factoryName", "The name of the Piggy Bank Factory contract.")
+.addParam("factoryAddress", "The address of the Piggy Bank Factory contract.")
+.addParam("masterAddress", "The address of the Piggy Bank Master contract.")
+.addParam("createMethod", "The signature of the the Piggy Bank creation method of the Factory.")
+.addParam("createArgList", "Semicolon separated list of arguments to pass into the Piggy Bank creation method of the Factory.")
+.setAction(async ({
+    piggyBankName,
+    factoryName,
+    factoryAddress,
+    masterAddress,
+    createMethod,
+    createArgList
+  }, {
+    ethers,
+    run
+  }) => {
+    const Master = await ethers.getContractFactory("PiggyBankMaster");
+    const master = Master.attach(masterAddress);
+
+    factoryName = factoryName ?? `${piggyBankName}Factory`;
+
+    const Factory = await ethers.getContractFactory(factoryName);
+    const factory = Factory.attach(factoryAddress);
+
+    console.log(`Creating ${piggyBankName} via its Factory...`);
+
+    const createArgs = createArgList.split(";");
+    const createTx = await factory.functions[createMethod](...createArgs);
+    await createTx.wait(MIN_CONFIRMATIONS_TO_WAIT);
+    // TODO:  Consider using event to get address of the newly created Piggy Bank.
+
+    console.log(`A new ${piggyBankName} created.`);
+    console.log(`Querying Master for the address of the new ${piggyBankName} contract...`);
+
+    // WARNING:  This approach is extremely fragile as there is no guarantee that the 1st
+    //           argument is exactly an owner. Currently, it's just a kinda convention.
+    const owner = createArgs[0];
+
+    const piggyBanks = await master.callStatic.getPiggyBanksByOwner(owner);
+    const lastPiggyBankAddress = piggyBanks.at(-1).piggyBankAddress;
+
+    console.log(`The new ${piggyBankName} contract was deployed to ${lastPiggyBankAddress}.`);
+
+    console.log(`Verifying ${piggyBankName} source code at etherscan...`);
+
+    try {
+      await run("verify:verify", {
+        address: lastPiggyBankAddress,
+        // contract format: <path-to-contract>:<contract-name>
+        contract: `contracts/${piggyBankName}.sol:${piggyBankName}`,
+        constructorArguments: createArgs
+      });
+    } catch (error) {
+      if (error.toString().includes("Reason: Already Verified")) {
+        console.log(`${piggyBankName} source code was already verified.`);
+        
+      } else {
+        throw error;
+      }
+    }
+  }
+);
+
+task(
+  "add-factory-and-verify-piggy-bank-at-etherscan",
+  "Creates a new Factory and registers it in Master, " +
+  "and then verifies and publishes Piggy Bank source code.")
+.addParam("piggyBankName", "The name of the Piggy Bank contract.")
+.addOptionalParam("factoryName", "The name of the Piggy Bank Factory contract.")
+.addParam("piggyBankType", "The key under which the Factory will be registered in the Master.")
+.addParam("masterAddress", "The address of the Piggy Bank Master contract.")
+.addParam("createMethod", "The signature of the the Piggy Bank creation method of the Factory.")
+.addParam("createArgList", "Semicolon separated list of arguments to pass into the Piggy Bank creation method of the Factory.")
+.setAction(async ({
+    piggyBankName,
+    factoryName,
+    piggyBankType,
+    masterAddress,
+    createMethod,
+    createArgList
+  }, {
+    run
+  }) => {
+    factoryName = factoryName ?? `${piggyBankName}Factory`;
+
+    const factoryAddress = await run("add-factory", {
+      factoryName,
+      piggyBankType,
+      masterAddress
+    });
+
+    await run("verify-piggy-bank-at-etherscan", {
+      piggyBankName,
+      factoryName,
+      factoryAddress,
+      masterAddress,
+      createMethod,
+      createArgList
+    });
+});


### PR DESCRIPTION
Adds Hardhat tasks for Factories:
1. Add new factory.
2. Verify BiggyBank source code at etherscan.
3. Combine the two ones above.

Contract example that was verified programmatically via Hardhat task:
* [0x7F3097E7ed1f9C7E14b48c9D17D221e406225203](https://rinkeby.etherscan.io/address/0x7F3097E7ed1f9C7E14b48c9D17D221e406225203#code).

Two contracts of same type whose source code was automatically detected as "Similar Match Source Code":
* [0x821e10bE9c2A75b01A34C194B78fAA9Ca460718f](https://rinkeby.etherscan.io/address/0x821e10bE9c2A75b01A34C194B78fAA9Ca460718f#code)
* [0xfEf248e263F32367559FC5fc9a0Eee56E2836284](https://rinkeby.etherscan.io/address/0xfEf248e263F32367559FC5fc9a0Eee56E2836284#code)

Programmatical verification of already verified contract fails with the following error:
```output
Error in plugin @nomiclabs/hardhat-etherscan: The Etherscan API responded with a failure status.
The verification may still succeed but should be checked manually.
Reason: Already Verified
```

The error above is handled and supressed.

Note: the overall approach may seem to be verbose and overcomplicated. Please share your thoughts on it.