### PR TITLE
Resolve type of Piggy Bank

### DIFF
--- a/hardhat/contracts/PiggyBankMaster.sol
+++ b/hardhat/contracts/PiggyBankMaster.sol
@@ -14,6 +14,7 @@ contract PiggyBankMaster is IPiggyBankObserver {
     mapping(address => string) private factoryTypes;
 
     mapping(address => PiggyBankDetails[]) piggyBanksByOwner;
+    mapping(address => string) piggyBankTypes;
 
     function registerPiggyBankFactory(
         string memory _piggyBankType,
@@ -34,15 +35,25 @@ contract PiggyBankMaster is IPiggyBankObserver {
     ) override external {
         require(registeredFactories[msg.sender], "Not a known factory!");
 
+        string memory piggyBankType = factoryTypes[msg.sender];
+
         piggyBanksByOwner[_owner].push(PiggyBankDetails({
             piggyBankAddress: _newPiggyBank,
-            piggyBankType: factoryTypes[msg.sender]
+            piggyBankType: piggyBankType
         }));
+
+        piggyBankTypes[_newPiggyBank] = piggyBankType;
     }
 
     function getPiggyBanksByOwner(
         address _owner
     ) external view returns (PiggyBankDetails[] memory) {
         return piggyBanksByOwner[_owner];
+    }
+
+    function getPiggyBankType(
+        address _piggyBank
+    ) external view returns (string memory) {
+        return piggyBankTypes[_piggyBank];
     }
 }

--- a/hardhat/contracts/PiggyBankMaster.sol
+++ b/hardhat/contracts/PiggyBankMaster.sol
@@ -9,8 +9,8 @@ contract PiggyBankMaster is IPiggyBankObserver {
         string piggyBankType;
     }
 
-    mapping(address => bool) private factories;
-    mapping(string => bool) private piggyBankTypes;
+    mapping(address => bool) private registeredFactories;
+    mapping(string => bool) private registeredPiggyBankTypes;
     mapping(address => string) private factoryTypes;
 
     mapping(address => PiggyBankDetails[]) piggyBanksByOwner;
@@ -20,11 +20,11 @@ contract PiggyBankMaster is IPiggyBankObserver {
         address _factory
     ) external {
         // TODO:  Add authorizatoin check.
-        require(!factories[_factory], "Factory is already registered!");
-        require(!piggyBankTypes[_piggyBankType], "Piggy bank type is already in use!");
+        require(!registeredFactories[_factory], "Factory is already registered!");
+        require(!registeredPiggyBankTypes[_piggyBankType], "Piggy bank type is already in use!");
 
-        factories[_factory] = true;
-        piggyBankTypes[_piggyBankType] = true;
+        registeredFactories[_factory] = true;
+        registeredPiggyBankTypes[_piggyBankType] = true;
         factoryTypes[_factory] = _piggyBankType;
     }
 
@@ -32,7 +32,7 @@ contract PiggyBankMaster is IPiggyBankObserver {
         address _owner,
         address _newPiggyBank
     ) override external {
-        require(factories[msg.sender], "Not a known factory!");
+        require(registeredFactories[msg.sender], "Not a known factory!");
 
         piggyBanksByOwner[_owner].push(PiggyBankDetails({
             piggyBankAddress: _newPiggyBank,

--- a/hardhat/test/PiggyBankMaster.js
+++ b/hardhat/test/PiggyBankMaster.js
@@ -118,4 +118,39 @@ describe("PiggyBankMaster", function () {
       expect(await piggyBankMaster.getPiggyBanksByOwner(owner.address)).to.be.empty;
     });
   });
+
+  describe("Resolving Piggy Bank Type", function () {
+    it("Should resolve Piggy Bank Type by Piggy Bank address", async function () {
+      const { piggyBankMaster, owner } = await loadFixture(deployPiggyBankMasterFixture);
+      
+      const AmountPiggyBankFactory = await ethers.getContractFactory("AmountPiggyBankFactory");
+      const amountPiggyBankFactory = await AmountPiggyBankFactory.deploy(piggyBankMaster.address);
+
+      const expectedPiggyBankType = "Approve";
+
+      const registrationTx = await piggyBankMaster.registerPiggyBankFactory(expectedPiggyBankType, amountPiggyBankFactory.address);
+      await registrationTx.wait();
+
+      const description = "Amount Piggy Bank (1)";
+      const targetAmount = 42;
+
+      const amountPiggyBankAddress = await amountPiggyBankFactory.callStatic.createAmountPiggyBank(
+        owner.address,
+        description,
+        targetAmount);
+
+      const creationTx = await amountPiggyBankFactory.createAmountPiggyBank(
+        owner.address,
+        description,
+        targetAmount);
+
+      await creationTx.wait(); 
+
+      const actualPiggyBankType = await piggyBankMaster.callStatic.getPiggyBankType(
+        amountPiggyBankAddress
+      );
+
+      expect(actualPiggyBankType).to.be.eq(expectedPiggyBankType);
+    });
+  });
 });


### PR DESCRIPTION
* Store Piggy Bank address to type mapping in Master
* Resolve Piggy Bank type by its address via `getPiggyBankType` method of Master.
* Cover the new method with unit test.